### PR TITLE
Fix argument processing for call

### DIFF
--- a/otto_.go
+++ b/otto_.go
@@ -20,12 +20,12 @@ func (self *_runtime) toValueArray(arguments ...interface{}) []Value {
 		if valueArray, ok := arguments[0].([]Value); ok {
 			return valueArray
 		}
-		return []Value{toValue(arguments[0])}
+		return []Value{self.toValue(arguments[0])}
 	}
 
 	valueArray := make([]Value, length)
 	for index, value := range arguments {
-		valueArray[index] = toValue(value)
+		valueArray[index] = self.toValue(value)
 	}
 
 	return valueArray

--- a/otto_test.go
+++ b/otto_test.go
@@ -969,6 +969,9 @@ func TestOttoCall(t *testing.T) {
                     return "def: " + (def + 3.14159 + ghi);
                 }
             };
+            function structFunc(s) {
+                return s.Val;
+            }
         `)
 		is(err, nil)
 
@@ -988,6 +991,11 @@ func TestOttoCall(t *testing.T) {
 		value, err = vm.Call(`[ 1, 2, 3, undefined, 4 ].concat`, nil, 5, 6, 7, "abc")
 		is(err, nil)
 		is(value, "1,2,3,,4,5,6,7,abc")
+
+		s := struct{ Val int }{Val: 10}
+		value, err = vm.Call("structFunc", nil, s)
+		is(err, nil)
+		is(value, 10)
 	})
 }
 


### PR DESCRIPTION
Fix toValueArray causing "missing runtime" errors due to use of toValue instead of self.toValue which causeed issues with passing values to Otto.Call(...).
