### PR TITLE
Prevent loss of float precision

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -236,7 +236,7 @@ func Test_reflectStruct(t *testing.T) {
 
 			test(`raise:
                 abc.Func1Int(1.1);
-            `, "reflect: Call using float64 as type int")
+            `, "converting float64 to int would cause loss of precision")
 
 			test(`
 		var v = 1;
@@ -429,14 +429,14 @@ func Test_reflectSlice(t *testing.T) {
                 abc;
             `, "0,0,0,0")
 
-			test(`
-                abc[0] = 4.2;
-                abc[1] = "42";
+			test(`raise:
+                abc[0] = "42";
+                abc[1] = 4.2;
                 abc[2] = 3.14;
                 abc;
-            `, "4,42,3,0")
+            `, "RangeError: 4.2 to reflect.Kind: int32")
 
-			is(abc, []int32{4, 42, 3, 0})
+			is(abc, []int32{42, 0, 0, 0})
 
 			test(`
                 delete abc[1];
@@ -488,14 +488,14 @@ func Test_reflectArray(t *testing.T) {
                 abc;
             `, "0,0,0,0")
 
-			test(`
-                abc[0] = 4.2;
-                abc[1] = "42";
+			test(`raise:
+                abc[0] = "42";
+                abc[1] = 4.2;
                 abc[2] = 3.14;
                 abc;
-            `, "4,42,3,0")
+            `, "RangeError: 4.2 to reflect.Kind: int32")
 
-			is(abc, []int32{4, 42, 3, 0})
+			is(abc, []int32{42, 0, 0, 0})
 		}
 
 		// []bool

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -213,9 +213,14 @@ func Test_reflectStruct(t *testing.T) {
                 abc.FuncEllipsis("abc", "def", "ghi");
             `, 3)
 
-			test(`raise:
-                abc.FuncReturn2();
-            `, "TypeError")
+			test(`
+                ret = abc.FuncReturn2();
+                if (ret && ret.length && ret.length == 2 && ret[0] == "def" && ret[1] === undefined) {
+                        true;
+                } else {
+                       false;
+                }
+            `, true)
 
 			test(`
                 abc.FuncReturnStruct();

--- a/runtime.go
+++ b/runtime.go
@@ -285,13 +285,21 @@ func (self *_runtime) toValue(value interface{}) Value {
 					}
 
 					out := value.Call(in)
-					if len(out) == 1 {
-						return self.toValue(out[0].Interface())
-					} else if len(out) == 0 {
+					l := len(out)
+					switch l {
+					case 0:
 						return Value{}
+					case 1:
+						return self.toValue(out[0].Interface())
 					}
 
-					panic(call.runtime.panicTypeError())
+					// Return an array of the values to emulate multi value return.
+					// In the future this can be used along side destructuring assignment.
+					s := make([]interface{}, l)
+					for i, v := range out {
+						s[i] = self.toValue(v.Interface())
+					}
+					return self.toValue(s)
 				}))
 			case reflect.Struct:
 				return toValue_object(self.newGoStructObject(value))

--- a/value.go
+++ b/value.go
@@ -770,6 +770,21 @@ func (self Value) exportNative() interface{} {
 // Make a best effort to return a reflect.Value corresponding to reflect.Kind, but
 // fallback to just returning the Go value we have handy.
 func (value Value) toReflectValue(kind reflect.Kind) (reflect.Value, error) {
+	if kind != reflect.Float32 && kind != reflect.Float64 && kind != reflect.Interface {
+		switch value := value.value.(type) {
+		case float32:
+			_, frac := math.Modf(float64(value))
+			if frac > 0 {
+				return reflect.Value{}, fmt.Errorf("RangeError: %v to reflect.Kind: %v", value, kind)
+			}
+		case float64:
+			_, frac := math.Modf(value)
+			if frac > 0 {
+				return reflect.Value{}, fmt.Errorf("RangeError: %v to reflect.Kind: %v", value, kind)
+			}
+		}
+	}
+
 	switch kind {
 	case reflect.Bool: // Bool
 		return reflect.ValueOf(value.bool()), nil


### PR DESCRIPTION
When automatically converting a float to int type ensure we don't loose any precision.
