### PR TITLE
Export arrays to common type if possible

### DIFF
--- a/reflect_test.go
+++ b/reflect_test.go
@@ -523,6 +523,46 @@ func Test_reflectArray(t *testing.T) {
 			is(abc[len(abc)-1], true)
 		}
 
+		// no common type
+		{
+			test(`
+                 abc = [1, 2.2, "str"];
+                 abc;
+             `, "1,2.2,str")
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []interface{}{int64(1), 2.2, "str"})
+		}
+
+		// common type int
+		{
+			test(`
+                 abc = [1, 2, 3];
+                 abc;
+             `, "1,2,3")
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []int64{1, 2, 3})
+		}
+
+		// common type string
+		{
+
+			test(`
+                 abc = ["str1", "str2", "str3"];
+                 abc;
+             `, "str1,str2,str3")
+
+			val, err := vm.Get("abc")
+			is(err, nil)
+			abc, err := val.Export()
+			is(err, nil)
+			is(abc, []string{"str1", "str2", "str3"})
+		}
 	})
 }
 


### PR DESCRIPTION
If there is a common type for all values in an array export to a slice of that type otherwise return a slice of interfaces.
